### PR TITLE
Update travis to migrate database on deployment and add rubocop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ script:
   - bin/rails db:create 
   - bin/rails db:migrate
   - bundle exec rspec
+  - bundle exec rubocop
 services:
  — postgresql
 deploy:
@@ -17,3 +18,4 @@ deploy:
   app: tavern-keepers
   on:
   repo: jennybell/dnd-finder
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ script:
   - bin/rails db:create 
   - bin/rails db:migrate
   - bundle exec rspec
-  - bundle exec rubocop
 services:
  — postgresql
 deploy:
@@ -18,4 +17,4 @@ deploy:
   app: tavern-keepers
   on:
   repo: jennybell/dnd-finder
-  
+  run: rake db:migrate

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'devise'
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 gem 'pg'
+gem 'rubocop'
 gem 'spring'
 
 # Reduces boot times through caching; required in config/boot.rb
@@ -32,13 +33,13 @@ gem 'bootsnap', '>= 1.4.4', require: false
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'rspec-rails', '~> 3.5'
+  gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'database_cleaner'
-  gem 'rexml'
   gem 'factory_bot_rails'
-  gem 'spring-commands-rspec'
+  gem 'rexml'
+  gem 'rspec-rails', '~> 3.5'
   gem 'simplecov'
+  gem 'spring-commands-rspec'
 end
 
 group :development do
@@ -46,12 +47,11 @@ group :development do
   gem 'web-console', '>= 4.1.0'
   # Display performance information such as SQL time and flame graphs for each request in your browser.
   # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
-  gem 'rack-mini-profiler', '~> 2.0'
   gem 'listen', '~> 3.3'
+  gem 'rack-mini-profiler', '~> 2.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  
+
   gem 'letter_opener'
-  
 end
 
 group :test do
@@ -63,4 +63,4 @@ group :test do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    ast (2.4.2)
     bcrypt (3.1.16)
     bindex (0.8.1)
     bootsnap (1.7.5)
@@ -129,6 +130,9 @@ GEM
     nokogiri (1.11.7-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    parallel (1.20.1)
+    parser (3.0.2.0)
+      ast (~> 2.4.1)
     pg (1.2.3)
     public_suffix (4.0.6)
     puma (5.3.2)
@@ -167,6 +171,7 @@ GEM
       method_source
       rake (>= 0.13)
       thor (~> 1.0)
+    rainbow (3.0.0)
     rake (13.0.6)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
@@ -193,6 +198,18 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.4)
+    rubocop (1.18.3)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.7.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.7.0)
+      parser (>= 3.0.1.1)
+    ruby-progressbar (1.11.0)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -231,6 +248,7 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    unicode-display_width (2.0.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.1.0)
@@ -274,6 +292,7 @@ DEPENDENCIES
   rails (~> 6.1.3, >= 6.1.3.2)
   rexml
   rspec-rails (~> 3.5)
+  rubocop
   sass-rails (>= 6)
   selenium-webdriver
   simplecov

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative "config/application"
+require_relative 'config/application'
 
 Rails.application.load_tasks

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:email, :location, :rating, :dm, :terms])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:email, :location, :dm])
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[email location rating dm terms])
+    devise_parameter_sanitizer.permit(:account_update, keys: %i[email location dm])
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,5 @@
 class HomeController < ApplicationController
   before_action :authenticate_user!
 
-  def index
-  end
+  def index; end
 end

--- a/bin/bundle
+++ b/bin/bundle
@@ -8,7 +8,7 @@
 # this file is here to facilitate running it.
 #
 
-require "rubygems"
+require 'rubygems'
 
 m = Module.new do
   module_function
@@ -18,36 +18,36 @@ m = Module.new do
   end
 
   def env_var_version
-    ENV["BUNDLER_VERSION"]
+    ENV['BUNDLER_VERSION']
   end
 
   def cli_arg_version
     return unless invoked_as_script? # don't want to hijack other binstubs
-    return unless "update".start_with?(ARGV.first || " ") # must be running `bundle update`
+    return unless 'update'.start_with?(ARGV.first || ' ') # must be running `bundle update`
+
     bundler_version = nil
     update_index = nil
     ARGV.each_with_index do |a, i|
-      if update_index && update_index.succ == i && a =~ Gem::Version::ANCHORED_VERSION_PATTERN
-        bundler_version = a
-      end
+      bundler_version = a if update_index && update_index.succ == i && a =~ Gem::Version::ANCHORED_VERSION_PATTERN
       next unless a =~ /\A--bundler(?:[= ](#{Gem::Version::VERSION_PATTERN}))?\z/
-      bundler_version = $1
+
+      bundler_version = Regexp.last_match(1)
       update_index = i
     end
     bundler_version
   end
 
   def gemfile
-    gemfile = ENV["BUNDLE_GEMFILE"]
+    gemfile = ENV['BUNDLE_GEMFILE']
     return gemfile if gemfile && !gemfile.empty?
 
-    File.expand_path("../../Gemfile", __FILE__)
+    File.expand_path('../Gemfile', __dir__)
   end
 
   def lockfile
     lockfile =
       case File.basename(gemfile)
-      when "gems.rb" then gemfile.sub(/\.rb$/, gemfile)
+      when 'gems.rb' then gemfile.sub(/\.rb$/, gemfile)
       else "#{gemfile}.lock"
       end
     File.expand_path(lockfile)
@@ -55,15 +55,17 @@ m = Module.new do
 
   def lockfile_version
     return unless File.file?(lockfile)
+
     lockfile_contents = File.read(lockfile)
     return unless lockfile_contents =~ /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/
+
     Regexp.last_match(1)
   end
 
   def bundler_version
     @bundler_version ||=
       env_var_version || cli_arg_version ||
-        lockfile_version
+      lockfile_version
   end
 
   def bundler_requirement
@@ -73,28 +75,32 @@ m = Module.new do
 
     requirement = bundler_gem_version.approximate_recommendation
 
-    return requirement unless Gem::Version.new(Gem::VERSION) < Gem::Version.new("2.7.0")
+    return requirement unless Gem::Version.new(Gem::VERSION) < Gem::Version.new('2.7.0')
 
-    requirement += ".a" if bundler_gem_version.prerelease?
+    requirement += '.a' if bundler_gem_version.prerelease?
 
     requirement
   end
 
   def load_bundler!
-    ENV["BUNDLE_GEMFILE"] ||= gemfile
+    ENV['BUNDLE_GEMFILE'] ||= gemfile
 
     activate_bundler
   end
 
   def activate_bundler
     gem_error = activation_error_handling do
-      gem "bundler", bundler_requirement
+      gem 'bundler', bundler_requirement
     end
     return if gem_error.nil?
+
     require_error = activation_error_handling do
-      require "bundler/version"
+      require 'bundler/version'
     end
-    return if require_error.nil? && Gem::Requirement.new(bundler_requirement).satisfied_by?(Gem::Version.new(Bundler::VERSION))
+    if require_error.nil? && Gem::Requirement.new(bundler_requirement).satisfied_by?(Gem::Version.new(Bundler::VERSION))
+      return
+    end
+
     warn "Activating bundler (#{bundler_requirement}) failed:\n#{gem_error.message}\n\nTo install the version of bundler this project requires, run `gem install bundler -v '#{bundler_requirement}'`"
     exit 42
   end
@@ -109,6 +115,4 @@ end
 
 m.load_bundler!
 
-if m.invoked_as_script?
-  load Gem.bin_path("bundler", "bundle")
-end
+load Gem.bin_path('bundler', 'bundle') if m.invoked_as_script?

--- a/bin/rails
+++ b/bin/rails
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-load File.expand_path("spring", __dir__)
+load File.expand_path('spring', __dir__)
 APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative "../config/boot"
-require "rails/commands"
+require_relative '../config/boot'
+require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-load File.expand_path("spring", __dir__)
-require_relative "../config/boot"
-require "rake"
+load File.expand_path('spring', __dir__)
+require_relative '../config/boot'
+require 'rake'
 Rake.application.run

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 begin
-  load File.expand_path('../spring', __FILE__)
+  load File.expand_path('spring', __dir__)
 rescue LoadError => e
   raise unless e.message.include?('spring')
 end

--- a/bin/setup
+++ b/bin/setup
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require "fileutils"
+require 'fileutils'
 
 # path to your application root.
 APP_ROOT = File.expand_path('..', __dir__)

--- a/bin/webpack
+++ b/bin/webpack
@@ -1,18 +1,18 @@
 #!/usr/bin/env ruby
 
-ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
-ENV["NODE_ENV"]  ||= "development"
+ENV['RAILS_ENV'] ||= ENV['RACK_ENV'] || 'development'
+ENV['NODE_ENV']  ||= 'development'
 
-require "pathname"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
-  Pathname.new(__FILE__).realpath)
+require 'pathname'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile',
+                                           Pathname.new(__FILE__).realpath)
 
-require "bundler/setup"
+require 'bundler/setup'
 
-require "webpacker"
-require "webpacker/webpack_runner"
+require 'webpacker'
+require 'webpacker/webpack_runner'
 
-APP_ROOT = File.expand_path("..", __dir__)
+APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
   Webpacker::WebpackRunner.run(ARGV)
 end

--- a/bin/webpack-dev-server
+++ b/bin/webpack-dev-server
@@ -1,18 +1,18 @@
 #!/usr/bin/env ruby
 
-ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
-ENV["NODE_ENV"]  ||= "development"
+ENV['RAILS_ENV'] ||= ENV['RACK_ENV'] || 'development'
+ENV['NODE_ENV']  ||= 'development'
 
-require "pathname"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
-  Pathname.new(__FILE__).realpath)
+require 'pathname'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile',
+                                           Pathname.new(__FILE__).realpath)
 
-require "bundler/setup"
+require 'bundler/setup'
 
-require "webpacker"
-require "webpacker/dev_server_runner"
+require 'webpacker'
+require 'webpacker/dev_server_runner'
 
-APP_ROOT = File.expand_path("..", __dir__)
+APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
   Webpacker::DevServerRunner.run(ARGV)
 end

--- a/bin/yarn
+++ b/bin/yarn
@@ -1,17 +1,17 @@
 #!/usr/bin/env ruby
 APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
-  yarn = ENV["PATH"].split(File::PATH_SEPARATOR).
-    select { |dir| File.expand_path(dir) != __dir__ }.
-    product(["yarn", "yarn.cmd", "yarn.ps1"]).
-    map { |dir, file| File.expand_path(file, dir) }.
-    find { |file| File.executable?(file) }
+  yarn = ENV['PATH'].split(File::PATH_SEPARATOR)
+                    .select { |dir| File.expand_path(dir) != __dir__ }
+                    .product(['yarn', 'yarn.cmd', 'yarn.ps1'])
+                    .map { |dir, file| File.expand_path(file, dir) }
+                    .find { |file| File.executable?(file) }
 
   if yarn
     exec yarn, *ARGV
   else
-    $stderr.puts "Yarn executable was not detected in the system."
-    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
+    warn 'Yarn executable was not detected in the system.'
+    warn 'Download Yarn at https://yarnpkg.com/en/docs/install'
     exit 1
   end
 end

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,6 @@
 # This file is used by Rack-based servers to start the application.
 
-require_relative "config/environment"
+require_relative 'config/environment'
 
 run Rails.application
 Rails.application.load_server

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,6 @@
-require_relative "boot"
+require_relative 'boot'
 
-require "rails/all"
+require 'rails/all'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
-require "bundler/setup" # Set up gems listed in the Gemfile.
-require "bootsnap/setup" # Speed up boot time by caching expensive operations.
+require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup' # Speed up boot time by caching expensive operations.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require_relative "application"
+require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,4 @@
-require "active_support/core_ext/integer/time"
+require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -76,6 +76,4 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
-  
 end
-

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,4 @@
-require "active_support/core_ext/integer/time"
+require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -53,7 +53,7 @@ Rails.application.configure do
   config.log_level = :info
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -88,7 +88,7 @@ Rails.application.configure do
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,4 @@
-require "active_support/core_ext/integer/time"
+require 'active_support/core_ext/integer/time'
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -5,4 +5,4 @@
 
 # You can also remove all the silencers if you're trying to debug a problem that might stem from framework code
 # by setting BACKTRACE=1 before calling your invocation, like "BACKTRACE=1 ./bin/rails runner 'MyClass.perform'".
-Rails.backtrace_cleaner.remove_silencers! if ENV["BACKTRACE"]
+Rails.backtrace_cleaner.remove_silencers! if ENV['BACKTRACE']

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [
-  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+Rails.application.config.filter_parameters += %i[
+  passw secret token _key crypt salt certificate otp ssn
 ]

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,25 +4,25 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
+min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
 threads min_threads_count, max_threads_count
 
 # Specifies the `worker_timeout` threshold that Puma will use to wait before
 # terminating a worker in development environments.
 #
-worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
+worker_timeout 3600 if ENV.fetch('RAILS_ENV', 'development') == 'development'
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch("PORT") { 3000 }
+port ENV.fetch('PORT') { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch('RAILS_ENV') { 'development' }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   devise_for :users
-  root to: "home#index"
+  root to: 'home#index'
 end

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,6 +1,6 @@
 Spring.watch(
-  ".ruby-version",
-  ".rbenv-vars",
-  "tmp/restart.txt",
-  "tmp/caching-dev.txt"
+  '.ruby-version',
+  '.rbenv-vars',
+  'tmp/restart.txt',
+  'tmp/caching-dev.txt'
 )

--- a/db/migrate/20210712133642_devise_create_users.rb
+++ b/db/migrate/20210712133642_devise_create_users.rb
@@ -4,8 +4,8 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.1]
   def change
     create_table :users do |t|
       ## Database authenticatable
-      t.string :email,              null: false, default: ""
-      t.string :encrypted_password, null: false, default: ""
+      t.string :email,              null: false, default: ''
+      t.string :encrypted_password, null: false, default: ''
 
       ## Recoverable
       t.string   :reset_password_token
@@ -31,7 +31,6 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.1]
       # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
       # t.string   :unlock_token # Only if unlock strategy is :email or :both
       # t.datetime :locked_at
-
 
       t.timestamps null: false
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,25 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_13_094948) do
-
+ActiveRecord::Schema.define(version: 20_210_713_094_948) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "users", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.string "location"
-    t.integer "rating"
-    t.boolean "dm"
-    t.boolean "terms"
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  create_table 'users', force: :cascade do |t|
+    t.string 'email', default: '', null: false
+    t.string 'encrypted_password', default: '', null: false
+    t.string 'reset_password_token'
+    t.datetime 'reset_password_sent_at'
+    t.datetime 'remember_created_at'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.string 'location'
+    t.integer 'rating'
+    t.boolean 'dm'
+    t.boolean 'terms'
+    t.index ['email'], name: 'index_users_on_email', unique: true
+    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
   end
-
 end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,12 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe HomeController, type: :controller do
-
   # describe "GET #index" do
   #   it "returns http success" do
   #     get :index
   #     expect(response).to have_http_status(:success)
   #   end
   # end
-
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :user do
-    
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,8 +1,6 @@
-
-
 ENV['RAILS_ENV'] ||= 'test'
 require 'spec_helper'
-require File.expand_path('../../config/environment', __FILE__)
+require File.expand_path('../config/environment', __dir__)
 require 'rspec/rails'
 require 'database_cleaner'
 require 'capybara/rspec'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,53 +46,51 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end

--- a/spec/unit/test_spec.rb
+++ b/spec/unit/test_spec.rb
@@ -1,5 +1,5 @@
 # require 'rails_helper'
 
-# describe Test do 
+# describe Test do
 
 # end

--- a/spec/views/home/index.html.erb_spec.rb
+++ b/spec/views/home/index.html.erb_spec.rb
@@ -1,4 +1,4 @@
 require 'rails_helper'
 
-RSpec.describe "home/index.html.erb", type: :view do
+RSpec.describe 'home/index.html.erb', type: :view do
 end


### PR DESCRIPTION
I have added rubocop to the project but it was causing Travis to fail so I have removed it from there - you can set up a 'fail rate' to pass but I don't have time before I leave. you can still run it from the command line. I have also added a line of code that auto migrates the database on deployment.