### PR TITLE
removing whitespace

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -39,7 +39,7 @@ test:
 #   <<: *default
 #   database: db/production.sqlite3
 
-  production:
+production:
   <<: *default
   database: pgapp_production
 


### PR DESCRIPTION
I think this should fix heroku. There was some whitespace in the database.yml file. yml does not like whitespace!